### PR TITLE
Return failed instead of error string in formatter

### DIFF
--- a/instrument.go
+++ b/instrument.go
@@ -139,10 +139,12 @@ func (i *instrument) Exec(fn func() error) error {
 	return err
 }
 
+// defaultFormatter , look into https://github.com/upfluence/errors/blob/master/stats/statuser.go#L36
+// for more advanced reporting
 func defaultFormatter(err error) string {
 	if err == nil {
 		return "success"
 	}
 
-	return err.Error()
+	return "failed"
 }

--- a/instrument_test.go
+++ b/instrument_test.go
@@ -157,7 +157,7 @@ func TestInstrument(t *testing.T) {
 						},
 						{
 							Name:   "foo_total",
-							Labels: map[string]string{"status": "mock"},
+							Labels: map[string]string{"status": "failed"},
 							Value:  1,
 						},
 					},
@@ -208,7 +208,7 @@ func TestInstrumentVector(t *testing.T) {
 			},
 			{
 				Name:   "example_total",
-				Labels: map[string]string{"bar": "bar", "foo": "foo", "status": "mock"},
+				Labels: map[string]string{"bar": "bar", "foo": "foo", "status": "failed"},
 				Value:  1,
 			},
 			{


### PR DESCRIPTION
### What does this PR do?

Return failed in the default formatter. This should prevent building unexpected metrics cardinality as the errors message can contains highly variable elements. 

For a smarter formatter look into [errors/stats#GetStatus](https://github.com/upfluence/errors/blob/master/stats/statuser.go#L36)

Related to : https://github.com/upfluence/creator-server/pull/107

### What are the observable changes?

Only two metrics by default.

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled
